### PR TITLE
fix:copy env

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -26,6 +26,7 @@ frontend:
         - mkdir -p .amplify-hosting/compute
         - mv .amplify-hosting/server .amplify-hosting/compute/default
         - npm ci --omit dev
+        - cp .env .amplify-hosting/compute/default
         - cp package.json .amplify-hosting/compute/default
         - cp -r node_modules .amplify-hosting/compute/default
         - cp server.js .amplify-hosting/compute/default


### PR DESCRIPTION
## 概要

- ビルド時に `.env` がコピーされるように修正