### PR TITLE
fix: upgrade library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "i18next-fs-backend": "^2.6.1",
         "i18next-http-backend": "^3.0.2",
         "isbot": "^5.1.32",
-        "react": "^19.2.1",
-        "react-dom": "^19.2.1",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "react-i18next": "^16.3.5",
         "react-router": "^7.10.1",
         "remix-i18next": "^7.4.2"
@@ -7577,9 +7577,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
-      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7631,15 +7631,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
-      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.1"
+        "react": "^19.2.3"
       }
     },
     "node_modules/react-i18next": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "i18next-fs-backend": "^2.6.1",
     "i18next-http-backend": "^3.0.2",
     "isbot": "^5.1.32",
-    "react": "^19.2.1",
-    "react-dom": "^19.2.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "react-i18next": "^16.3.5",
     "react-router": "^7.10.1",
     "remix-i18next": "^7.4.2"


### PR DESCRIPTION
## 概要

- Reactに脆弱性が見つかったのでアップグレード

## 関連

- https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade React and React DOM to 19.2.3.
> 
> - **Dependencies**:
>   - Upgrade `react` and `react-dom` to `^19.2.3` in `package.json` (and lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b3ee4f19310ba70b7be02e01dc061356ae86e0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->