### PR TITLE
add: components base tag

### DIFF
--- a/app/components/primitives/buttons/PrimitiveButton/index.tsx
+++ b/app/components/primitives/buttons/PrimitiveButton/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react'
+import { type AriaRole, type AriaAttributes, type ReactNode, useMemo } from 'react'
 import { Link } from 'react-router'
 
 import * as styles from './style.css'
@@ -17,47 +17,108 @@ export type PrimitiveButtonProps = {
   onClick?: EventTypes['onClickButton']
   name?: string
   value?: string
+  title?: string
+  role?: AriaRole
+  tabIndex?: number
+  ariaLabel?: AriaAttributes['aria-label']
+  ariaControls?: AriaAttributes['aria-controls']
+  ariaSelected?: AriaAttributes['aria-selected']
 }
 
 export const PrimitiveButton = ({
   url,
   target,
   rel,
-  buttonType = 'button',
+  buttonType,
   isDisabled,
   className,
   children,
   onClick,
   name,
   value,
+  title,
+  role,
+  tabIndex,
+  ariaLabel,
+  ariaControls,
+  ariaSelected,
 }: PrimitiveButtonProps) => {
   // 外部リンク判定
   const isExternal: boolean = useMemo(() => {
     return url ? url.startsWith('http://') || url.startsWith('https://') : false
   }, [url])
 
+  // 内部リンク判定
+  const isInternalLink: boolean = useMemo(() => {
+    return url ? url.startsWith('#') : false
+  }, [url])
+
   const primitiveButtonClassName = useMemo(() => {
     return [styles.primitiveButton, isDisabled && styles.primitiveButton__disabled, className].filter(Boolean).join(' ')
   }, [isDisabled, className])
 
-  return isExternal ? (
-    <a href={url} target={target} rel={rel} className={primitiveButtonClassName} onClick={onClick}>
+  // Button type
+  const type = buttonType || 'button'
+
+  return isExternal || isInternalLink ? (
+    <a
+      href={url}
+      target={target}
+      rel={rel}
+      className={primitiveButtonClassName}
+      onClick={onClick}
+      title={title}
+      role={role}
+      tabIndex={tabIndex}
+      aria-label={ariaLabel}
+      aria-controls={ariaControls}
+      aria-selected={ariaSelected}
+    >
       {children}
     </a>
   ) : url ? (
-    <Link to={url} target={target} rel={rel} className={primitiveButtonClassName} onClick={onClick}>
+    <Link
+      to={url}
+      target={target}
+      rel={rel}
+      className={primitiveButtonClassName}
+      onClick={onClick}
+      title={title}
+      role={role}
+      tabIndex={tabIndex}
+      aria-label={ariaLabel}
+      aria-controls={ariaControls}
+      aria-selected={ariaSelected}
+    >
       {children}
     </Link>
-  ) : (
+  ) : onClick || buttonType ? (
     <button
-      type={buttonType}
+      type={type}
       onClick={onClick}
       disabled={isDisabled}
       className={primitiveButtonClassName}
       name={name}
       value={value}
+      title={title}
+      role={role}
+      tabIndex={tabIndex}
+      aria-label={ariaLabel}
+      aria-controls={ariaControls}
+      aria-selected={ariaSelected}
     >
       {children}
     </button>
+  ) : (
+    <span
+      className={primitiveButtonClassName}
+      title={title}
+      role={role}
+      aria-controls={ariaControls}
+      aria-selected={ariaSelected}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </span>
   )
 }

--- a/app/components/primitives/buttons/PrimitiveButton/index.tsx
+++ b/app/components/primitives/buttons/PrimitiveButton/index.tsx
@@ -114,6 +114,7 @@ export const PrimitiveButton = ({
       className={primitiveButtonClassName}
       title={title}
       role={role}
+      tabIndex={tabIndex}
       aria-controls={ariaControls}
       aria-selected={ariaSelected}
       aria-label={ariaLabel}

--- a/app/components/ui/buttons/BaseButton/index.tsx
+++ b/app/components/ui/buttons/BaseButton/index.tsx
@@ -38,9 +38,9 @@ export const BaseButton = ({
   return (
     <PrimitiveButton {...props} className={baseButtonClassName} isDisabled={isDisabled}>
       <span className={styles.baseButton_container}>
-        {leftElm && leftElm}
+        {leftElm}
         <span className={styles.baseButton_text}>{children}</span>
-        {rightElm && rightElm}
+        {rightElm}
       </span>
     </PrimitiveButton>
   )

--- a/app/components/ui/buttons/BaseButton/index.tsx
+++ b/app/components/ui/buttons/BaseButton/index.tsx
@@ -36,11 +36,7 @@ export const BaseButton = ({
   }, [isDisabled, className, size, variant, color])
 
   return (
-    <PrimitiveButton
-      {...props}
-      className={[baseButtonClassName, className].filter(Boolean).join(' ')}
-      isDisabled={isDisabled}
-    >
+    <PrimitiveButton {...props} className={baseButtonClassName} isDisabled={isDisabled}>
       <span className={styles.baseButton_container}>
         {leftElm && leftElm}
         <span className={styles.baseButton_text}>{children}</span>

--- a/app/components/ui/lists/BaseTagList/index.tsx
+++ b/app/components/ui/lists/BaseTagList/index.tsx
@@ -1,0 +1,28 @@
+import * as styles from './style.css'
+
+import { BaseTag, type BaseTagProps } from '~/components/ui/tags/BaseTag'
+
+type BaseTagListProps = {
+  className?: string
+  items: BaseTagProps[]
+  isNotSemantic?: boolean
+  align?: 'left' | 'center' | 'right'
+}
+
+export const BaseTagList = ({ className, items, isNotSemantic, align = 'left' }: BaseTagListProps) => {
+  const Wrapper = isNotSemantic ? 'span' : 'div'
+  const Items = isNotSemantic ? 'span' : 'ul'
+  const Item = isNotSemantic ? 'span' : 'li'
+
+  return (
+    <Wrapper className={[styles.baseTagList, className].filter(Boolean).join(' ')}>
+      <Items className={[styles.baseTagList_items, styles[`baseTagList_items__${align}`]].filter(Boolean).join(' ')}>
+        {items.map((item, i) => (
+          <Item key={i} className={styles.baseTagList_item}>
+            <BaseTag {...item} />
+          </Item>
+        ))}
+      </Items>
+    </Wrapper>
+  )
+}

--- a/app/components/ui/lists/BaseTagList/style.css.ts
+++ b/app/components/ui/lists/BaseTagList/style.css.ts
@@ -1,0 +1,53 @@
+import { style } from '@vanilla-extract/css'
+
+import { cssLayerComponentUiMiddle } from '~/styles/variables/layers.css'
+
+export const baseTagList = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      display: 'block',
+    },
+  },
+})
+
+export const baseTagList_items__left = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      justifyContent: 'flex-start',
+    },
+  },
+})
+
+export const baseTagList_items__center = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      justifyContent: 'center',
+    },
+  },
+})
+
+export const baseTagList_items__right = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      justifyContent: 'flex-end',
+    },
+  },
+})
+
+export const baseTagList_items = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: 8,
+    },
+  },
+})
+
+export const baseTagList_item = style({
+  '@layer': {
+    [cssLayerComponentUiMiddle]: {
+      display: 'block',
+    },
+  },
+})

--- a/app/components/ui/tags/BaseTag/index.tsx
+++ b/app/components/ui/tags/BaseTag/index.tsx
@@ -40,9 +40,9 @@ export const BaseTag = ({
   return (
     <PrimitiveButton {...props} className={baseTagClassName} isDisabled={isDisabled} onClick={onClick} url={url}>
       <span className={styles.baseTag_container}>
-        {leftElm && leftElm}
+        {leftElm}
         <span className={styles.baseTag_text}>{children}</span>
-        {rightElm && rightElm}
+        {rightElm}
       </span>
     </PrimitiveButton>
   )

--- a/app/components/ui/tags/BaseTag/index.tsx
+++ b/app/components/ui/tags/BaseTag/index.tsx
@@ -1,0 +1,49 @@
+import { type ReactNode, useMemo } from 'react'
+
+import * as styles from './style.css'
+
+import { PrimitiveButton, type PrimitiveButtonProps } from '~/components/primitives/buttons/PrimitiveButton'
+
+export type BaseTagProps = PrimitiveButtonProps & {
+  variant?: 'contained' | 'outlined'
+  color?: 'sub'
+  children?: ReactNode
+  leftElm?: ReactNode
+  rightElm?: ReactNode
+}
+
+export const BaseTag = ({
+  isDisabled,
+  className,
+  children,
+  leftElm,
+  rightElm,
+  variant = 'contained',
+  color = 'sub',
+  onClick,
+  url,
+  ...props
+}: BaseTagProps) => {
+  const baseTagClassName = useMemo(() => {
+    return [
+      styles.baseTag,
+      styles[`baseTag__${variant}`],
+      styles[`baseTag__${color}`],
+      (url || onClick) && styles.baseTag__button,
+      isDisabled && styles.baseTag__disabled,
+      className,
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }, [variant, color, url, onClick, isDisabled, className])
+
+  return (
+    <PrimitiveButton {...props} className={baseTagClassName} isDisabled={isDisabled} onClick={onClick} url={url}>
+      <span className={styles.baseTag_container}>
+        {leftElm && leftElm}
+        <span className={styles.baseTag_text}>{children}</span>
+        {rightElm && rightElm}
+      </span>
+    </PrimitiveButton>
+  )
+}

--- a/app/components/ui/tags/BaseTag/index.tsx
+++ b/app/components/ui/tags/BaseTag/index.tsx
@@ -39,7 +39,14 @@ export const BaseTag = ({
   }, [variant, color, url, onClick, buttonType, isDisabled, className])
 
   return (
-    <PrimitiveButton {...props} className={baseTagClassName} isDisabled={isDisabled} onClick={onClick} url={url} buttonType={buttonType}>
+    <PrimitiveButton
+      {...props}
+      className={baseTagClassName}
+      isDisabled={isDisabled}
+      onClick={onClick}
+      url={url}
+      buttonType={buttonType}
+    >
       <span className={styles.baseTag_container}>
         {leftElm}
         <span className={styles.baseTag_text}>{children}</span>

--- a/app/components/ui/tags/BaseTag/index.tsx
+++ b/app/components/ui/tags/BaseTag/index.tsx
@@ -22,6 +22,7 @@ export const BaseTag = ({
   color = 'sub',
   onClick,
   url,
+  buttonType,
   ...props
 }: BaseTagProps) => {
   const baseTagClassName = useMemo(() => {
@@ -29,16 +30,16 @@ export const BaseTag = ({
       styles.baseTag,
       styles[`baseTag__${variant}`],
       styles[`baseTag__${color}`],
-      (url || onClick) && styles.baseTag__button,
+      (url || onClick || buttonType) && styles.baseTag__button,
       isDisabled && styles.baseTag__disabled,
       className,
     ]
       .filter(Boolean)
       .join(' ')
-  }, [variant, color, url, onClick, isDisabled, className])
+  }, [variant, color, url, onClick, buttonType, isDisabled, className])
 
   return (
-    <PrimitiveButton {...props} className={baseTagClassName} isDisabled={isDisabled} onClick={onClick} url={url}>
+    <PrimitiveButton {...props} className={baseTagClassName} isDisabled={isDisabled} onClick={onClick} url={url} buttonType={buttonType}>
       <span className={styles.baseTag_container}>
         {leftElm}
         <span className={styles.baseTag_text}>{children}</span>

--- a/app/components/ui/tags/BaseTag/style.css.ts
+++ b/app/components/ui/tags/BaseTag/style.css.ts
@@ -1,0 +1,127 @@
+import { style } from '@vanilla-extract/css'
+
+import { getMediaQuery } from '~/styles/mixins/mediaQuery.css'
+import { getTransition } from '~/styles/mixins/transition.css'
+import { cssVariables } from '~/styles/variables/cssVariables.css'
+import { fontCaption } from '~/styles/variables/font.css'
+import { cssLayerComponentUiLow } from '~/styles/variables/layers.css'
+
+export const baseTag__disabled = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {
+      cursor: 'not-allowed',
+      opacity: cssVariables.opacity.disabled,
+      pointerEvents: 'none',
+    },
+  },
+})
+
+export const baseTag__button = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {},
+  },
+})
+
+export const baseTag__contained = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {},
+  },
+})
+
+export const baseTag__outlined = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {},
+  },
+})
+
+export const baseTag__sub = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {
+      selectors: {
+        [`&${baseTag__contained}`]: {
+          backgroundColor: cssVariables.color.background.subDark.hex,
+          color: cssVariables.color.font.light.hex,
+          borderColor: cssVariables.color.border.subDark.hex,
+        },
+
+        [`&${baseTag__outlined}`]: {
+          backgroundColor: 'transparent',
+          color: cssVariables.color.font.subDark.hex,
+          borderColor: cssVariables.color.border.subDark.hex,
+        },
+      },
+
+      '@media': {
+        [getMediaQuery('hover')]: {
+          selectors: {
+            [`&${baseTag__button}${baseTag__contained}:hover`]: {
+              backgroundColor: cssVariables.color.background.light.hex,
+              color: cssVariables.color.font.subDark.hex,
+            },
+
+            [`&${baseTag__button}${baseTag__outlined}:hover`]: {
+              backgroundColor: cssVariables.color.background.subDark.hex,
+              color: cssVariables.color.font.light.hex,
+            },
+          },
+        },
+      },
+    },
+  },
+})
+
+export const baseTag = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {
+      ...fontCaption,
+      alignItems: 'center',
+      blockSize: 'auto',
+      display: 'inline-flex',
+      inlineSize: 'auto',
+      justifyContent: 'center',
+      marginBlock: 0,
+      marginInline: 0,
+      paddingBlock: 4,
+      paddingInline: 8,
+      position: 'relative',
+      textAlign: 'start',
+      textDecoration: 'none',
+      boxShadow: 'none',
+      borderRadius: 'calc(infinity * 1px)',
+      borderBlock: '1px solid',
+      borderInline: '1px solid',
+      transition: getTransition([
+        {
+          property: 'color',
+        },
+        {
+          property: 'opacity',
+        },
+        {
+          property: 'background-color',
+        },
+        {
+          property: 'border-color',
+        },
+      ]),
+    },
+  },
+})
+
+export const baseTag_container = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {
+      alignItems: 'center',
+      display: 'flex',
+      justifyContent: 'center',
+    },
+  },
+})
+
+export const baseTag_text = style({
+  '@layer': {
+    [cssLayerComponentUiLow]: {
+      display: 'block',
+    },
+  },
+})

--- a/stories/components/primitives/buttons/PrimitiveButton/index.stories.tsx
+++ b/stories/components/primitives/buttons/PrimitiveButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { createRoutesStub } from 'react-router'
 
 import { PrimitiveButton } from '~/components/primitives/buttons/PrimitiveButton'

--- a/stories/components/ui/buttons/BaseButton/index.stories.tsx
+++ b/stories/components/ui/buttons/BaseButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { createRoutesStub } from 'react-router'
 import { BaseButton } from '~/components/ui/buttons/BaseButton'
 

--- a/stories/components/ui/icons/SvgIcon/index.stories.tsx
+++ b/stories/components/ui/icons/SvgIcon/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { SvgIcon } from '~/components/ui/icons/SvgIcon'
 
 const meta: Meta<typeof SvgIcon> = {

--- a/stories/components/ui/layouts/LayoutInner/index.stories.tsx
+++ b/stories/components/ui/layouts/LayoutInner/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { LayoutInner } from '~/components/ui/layouts/LayoutInner'
 
 const meta: Meta<typeof LayoutInner> = {

--- a/stories/components/ui/layouts/LayoutMain/index.stories.tsx
+++ b/stories/components/ui/layouts/LayoutMain/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { LayoutMain } from '~/components/ui/layouts/LayoutMain'
 
 const meta: Meta<typeof LayoutMain> = {

--- a/stories/components/ui/layouts/LayoutPageWrapper/index.stories.tsx
+++ b/stories/components/ui/layouts/LayoutPageWrapper/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { LayoutPageWrapper } from '~/components/ui/layouts/LayoutPageWrapper'
 
 const meta: Meta<typeof LayoutPageWrapper> = {

--- a/stories/components/ui/layouts/LayoutWrapper/index.stories.tsx
+++ b/stories/components/ui/layouts/LayoutWrapper/index.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
 import { LayoutWrapper } from '~/components/ui/layouts/LayoutWrapper'
 
 const meta: Meta<typeof LayoutWrapper> = {

--- a/stories/components/ui/lists/BaseTagList/index.stories.tsx
+++ b/stories/components/ui/lists/BaseTagList/index.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { BaseTagList } from '~/components/ui/lists/BaseTagList'
+
+const meta: Meta<typeof BaseTagList> = {
+  title: 'components/ui/lists/BaseTagList',
+  component: BaseTagList,
+}
+export default meta
+
+type Story = StoryObj<typeof BaseTagList>
+
+export const Default: Story = {
+  args: {
+    items: [
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'contained',
+        color: 'sub',
+        onClick: () => {
+          alert('onClick')
+        },
+      },
+    ],
+  },
+}
+
+export const NotSemantic: Story = {
+  args: {
+    isNotSemantic: true,
+    items: [
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+      {
+        children: 'タグ名が入ります',
+        variant: 'outlined',
+        color: 'sub',
+      },
+    ],
+  },
+}

--- a/stories/components/ui/tags/BaseTag/index.stories.tsx
+++ b/stories/components/ui/tags/BaseTag/index.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { BaseTag } from '~/components/ui/tags/BaseTag'
+
+const meta: Meta<typeof BaseTag> = {
+  title: 'components/ui/tags/BaseTag',
+  component: BaseTag,
+}
+export default meta
+
+type Story = StoryObj<typeof BaseTag>
+
+export const ContainedSub: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'contained',
+    color: 'sub',
+  },
+}
+
+export const ContainedSubButton: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'contained',
+    color: 'sub',
+    onClick: () => {
+      alert('onClick')
+    },
+  },
+}
+
+export const ContainedSubButtonDisabled: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'contained',
+    color: 'sub',
+    onClick: () => {
+      alert('onClick')
+    },
+    isDisabled: true,
+  },
+}
+
+export const ContainedSubLink: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'contained',
+    color: 'sub',
+    url: 'https://example.com',
+  },
+}
+
+export const OutlinedSub: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'outlined',
+    color: 'sub',
+  },
+}
+
+export const OutlinedSubButton: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'outlined',
+    color: 'sub',
+    onClick: () => {
+      alert('onClick')
+    },
+  },
+}
+
+export const OutlinedSubButtonDisabled: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'outlined',
+    color: 'sub',
+    onClick: () => {
+      alert('onClick')
+    },
+    isDisabled: true,
+  },
+}
+
+export const OutlinedSubLink: Story = {
+  args: {
+    children: 'タグ名が入ります',
+    variant: 'outlined',
+    color: 'sub',
+    url: 'https://example.com',
+  },
+}

--- a/tests/components/primitives/buttons/PrimitiveButton/index.test.tsx
+++ b/tests/components/primitives/buttons/PrimitiveButton/index.test.tsx
@@ -49,10 +49,87 @@ describe('PrimitiveButton', () => {
       })
     })
 
+    describe('buttonType のみ指定（onClick なし）', () => {
+      describe('submit ボタン', () => {
+        beforeEach(() => {
+          result = render(<PrimitiveButton buttonType="submit">test</PrimitiveButton>)
+        })
+
+        test('button 要素がレンダリングされる', () => {
+          const button = result.container.querySelector('button')
+          expect(button).not.toBe(null)
+        })
+
+        test('type="submit" が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('type')).toEqual('submit')
+        })
+
+        test('span 要素はレンダリングされない', () => {
+          const span = result.container.querySelector('span')
+          expect(span).toBe(null)
+        })
+      })
+
+      describe('reset ボタン', () => {
+        beforeEach(() => {
+          result = render(<PrimitiveButton buttonType="reset">test</PrimitiveButton>)
+        })
+
+        test('button 要素がレンダリングされる', () => {
+          const button = result.container.querySelector('button')
+          expect(button).not.toBe(null)
+        })
+
+        test('type="reset" が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('type')).toEqual('reset')
+        })
+
+        test('span 要素はレンダリングされない', () => {
+          const span = result.container.querySelector('span')
+          expect(span).toBe(null)
+        })
+      })
+
+      describe('button タイプ', () => {
+        beforeEach(() => {
+          result = render(<PrimitiveButton buttonType="button">test</PrimitiveButton>)
+        })
+
+        test('button 要素がレンダリングされる', () => {
+          const button = result.container.querySelector('button')
+          expect(button).not.toBe(null)
+        })
+
+        test('type="button" が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('type')).toEqual('button')
+        })
+      })
+    })
+
+    describe('onClick も buttonType も指定しない場合', () => {
+      beforeEach(() => {
+        result = render(<PrimitiveButton>test</PrimitiveButton>)
+      })
+
+      test('span 要素がレンダリングされる', () => {
+        const span = result.container.querySelector('span')
+        expect(span).not.toBe(null)
+        expect(span?.textContent).toBe('test')
+      })
+
+      test('button 要素はレンダリングされない', () => {
+        const button = result.container.querySelector('button')
+        expect(button).toBe(null)
+      })
+    })
+
     describe('name と value 属性', () => {
       beforeEach(() => {
         result = render(
-          <PrimitiveButton name="testName" value="testValue">
+          <PrimitiveButton name="testName" value="testValue" onClick={() => handleClick()}>
             test
           </PrimitiveButton>
         )
@@ -62,6 +139,122 @@ describe('PrimitiveButton', () => {
         const button = result.container.querySelector('button')
         expect(button?.getAttribute('name')).toEqual('testName')
         expect(button?.getAttribute('value')).toEqual('testValue')
+      })
+    })
+
+    describe('title 属性', () => {
+      beforeEach(() => {
+        result = render(
+          <PrimitiveButton onClick={() => handleClick()} title="クリックして保存">
+            保存
+          </PrimitiveButton>
+        )
+      })
+
+      test('title が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('title')).toEqual('クリックして保存')
+      })
+    })
+
+    describe('ARIA 属性', () => {
+      describe('aria-label', () => {
+        beforeEach(() => {
+          result = render(
+            <PrimitiveButton onClick={() => handleClick()} ariaLabel="閉じる">
+              ×
+            </PrimitiveButton>
+          )
+        })
+
+        test('aria-label が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('aria-label')).toEqual('閉じる')
+        })
+      })
+
+      describe('aria-controls', () => {
+        beforeEach(() => {
+          result = render(
+            <PrimitiveButton onClick={() => handleClick()} ariaControls="menu-1">
+              Menu
+            </PrimitiveButton>
+          )
+        })
+
+        test('aria-controls が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('aria-controls')).toEqual('menu-1')
+        })
+      })
+
+      describe('aria-selected', () => {
+        beforeEach(() => {
+          result = render(
+            <PrimitiveButton onClick={() => handleClick()} ariaSelected="true">
+              Tab 1
+            </PrimitiveButton>
+          )
+        })
+
+        test('aria-selected が正常に付与されている', () => {
+          const button = result.container.querySelector('button')
+          expect(button?.getAttribute('aria-selected')).toEqual('true')
+        })
+      })
+    })
+
+    describe('role 属性', () => {
+      beforeEach(() => {
+        result = render(
+          <PrimitiveButton onClick={() => handleClick()} role="tab">
+            Tab
+          </PrimitiveButton>
+        )
+      })
+
+      test('role が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('role')).toEqual('tab')
+      })
+    })
+
+    describe('tabIndex 属性', () => {
+      beforeEach(() => {
+        result = render(
+          <PrimitiveButton onClick={() => handleClick()} tabIndex={-1}>
+            Button
+          </PrimitiveButton>
+        )
+      })
+
+      test('tabIndex が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('tabindex')).toEqual('-1')
+      })
+    })
+
+    describe('複数の ARIA 属性', () => {
+      beforeEach(() => {
+        result = render(
+          <PrimitiveButton
+            onClick={() => handleClick()}
+            role="tab"
+            ariaLabel="ホームタブ"
+            ariaControls="panel-1"
+            ariaSelected="true"
+          >
+            Home
+          </PrimitiveButton>
+        )
+      })
+
+      test('複数の ARIA 属性が同時に付与される', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('role')).toEqual('tab')
+        expect(button?.getAttribute('aria-label')).toEqual('ホームタブ')
+        expect(button?.getAttribute('aria-controls')).toEqual('panel-1')
+        expect(button?.getAttribute('aria-selected')).toEqual('true')
       })
     })
   })
@@ -92,7 +285,11 @@ describe('PrimitiveButton', () => {
 
     describe('カスタムクラス名', () => {
       beforeEach(() => {
-        result = render(<PrimitiveButton className="custom-class">test</PrimitiveButton>)
+        result = render(
+          <PrimitiveButton className="custom-class" onClick={() => handleClick()}>
+            test
+          </PrimitiveButton>
+        )
       })
 
       test('カスタムクラス名が正常に付与されている', () => {
@@ -199,6 +396,76 @@ describe('PrimitiveButton', () => {
 
         fireEvent.click(link)
         expect(handleClick).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('ハッシュリンクボタン', () => {
+      beforeEach(() => {
+        result = render(<PrimitiveButton url="#section-1">test</PrimitiveButton>)
+      })
+
+      test('a タグが使用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link).not.toBe(null)
+        expect(link?.getAttribute('href')).toEqual('#section-1')
+      })
+
+      test('button 要素はレンダリングされない', () => {
+        const button = result.container.querySelector('button')
+        expect(button).toBe(null)
+      })
+    })
+
+    describe('url と onClick の併用', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <PrimitiveButton url="/path" onClick={() => handleClick()}>
+              test
+            </PrimitiveButton>
+          </MemoryRouter>
+        )
+      })
+
+      test('url がある場合はリンク要素になる', () => {
+        const link = result.container.querySelector('a')
+        const button = result.container.querySelector('button')
+
+        expect(link).not.toBe(null)
+        expect(button).toBe(null)
+      })
+
+      test('onClick も正常に動作する', () => {
+        const link = result.container.querySelector('a')
+
+        if (!link) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(link)
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('非活性ボタンのクリック', () => {
+      beforeEach(() => {
+        result = render(
+          <PrimitiveButton onClick={() => handleClick()} isDisabled>
+            test
+          </PrimitiveButton>
+        )
+      })
+
+      test('非活性状態ではクリックイベントが発火しない', () => {
+        const button = result.container.querySelector('button')
+
+        if (!button) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(button)
+        // disabled なのでハンドラーは呼ばれない
+        expect(handleClick).not.toHaveBeenCalled()
       })
     })
   })

--- a/tests/components/ui/buttons/BaseButton/index.test.tsx
+++ b/tests/components/ui/buttons/BaseButton/index.test.tsx
@@ -1,130 +1,444 @@
-import { describe, vi, afterEach, beforeEach, test, expect } from 'vitest'
-import type { RenderResult } from '@testing-library/react'
-import { render, cleanup, fireEvent } from '@testing-library/react'
+import { render, type RenderResult, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, vi, beforeEach, afterEach, test, expect } from 'vitest'
+
 import { BaseButton } from '~/components/ui/buttons/BaseButton'
 
 describe('BaseButton', () => {
   let result: RenderResult
   const handleClick: () => void = vi.fn()
 
-  // テスト終了後の処理
   afterEach(() => {
     cleanup()
-    vi.resetAllMocks()
+    vi.clearAllMocks()
   })
 
-  describe('標準ボタン', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton onClick={() => handleClick()}>
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
+  //============================================================================
+  // 1. Input/Output
+  //============================================================================
+  describe('Input/Output', () => {
+    describe('標準ボタン', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('children が正常に出力されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button).not.toBe(null)
+        expect(button?.textContent).toBe('test')
+      })
+
+      test('type が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('type')).toEqual('button')
+      })
     })
 
-    test('テキストが正常に出力されている', () => {
-      const button = result.container.querySelector('button')
-      const text = button?.querySelector('.TestText')
-      expect(text).not.toBe(null)
-      expect(text?.innerHTML).toBe('test')
+    describe('submitボタン', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton buttonType="submit" onClick={() => handleClick()}>
+            test
+          </BaseButton>
+        )
+      })
+
+      test('type が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('type')).toEqual('submit')
+      })
     })
 
-    test('typeが正常に付与されている', () => {
-      const button = result.container.querySelector('button')
-      expect(button?.getAttribute('type')).toEqual('button')
+    describe('leftElm と rightElm', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton
+            onClick={() => handleClick()}
+            leftElm={<span data-testid="left">Left</span>}
+            rightElm={<span data-testid="right">Right</span>}
+          >
+            Center
+          </BaseButton>
+        )
+      })
+
+      test('leftElm が正常に出力されている', () => {
+        const leftElm = result.getByTestId('left')
+        expect(leftElm).not.toBe(null)
+        expect(leftElm.textContent).toBe('Left')
+      })
+
+      test('rightElm が正常に出力されている', () => {
+        const rightElm = result.getByTestId('right')
+        expect(rightElm).not.toBe(null)
+        expect(rightElm.textContent).toBe('Right')
+      })
+
+      test('children が正常に出力されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.textContent).toContain('Center')
+      })
     })
 
-    test('クリックイベントが正常に動作している', () => {
-      const button = result.container.querySelector('button')
+    describe('leftElm のみ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} leftElm={<span data-testid="left">Icon</span>}>
+            Button
+          </BaseButton>
+        )
+      })
 
-      if (!button) {
-        throw new Error('The target element was not found.')
-      }
+      test('leftElm が正常に出力されている', () => {
+        const leftElm = result.getByTestId('left')
+        expect(leftElm).not.toBe(null)
+      })
 
-      fireEvent.click(button)
-      expect(handleClick).toHaveBeenCalledTimes(1)
+      test('rightElm は出力されていない', () => {
+        const rightElm = result.queryByTestId('right')
+        expect(rightElm).toBe(null)
+      })
+    })
+
+    describe('rightElm のみ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} rightElm={<span data-testid="right">Arrow</span>}>
+            Button
+          </BaseButton>
+        )
+      })
+
+      test('rightElm が正常に出力されている', () => {
+        const rightElm = result.getByTestId('right')
+        expect(rightElm).not.toBe(null)
+      })
+
+      test('leftElm は出力されていない', () => {
+        const leftElm = result.queryByTestId('left')
+        expect(leftElm).toBe(null)
+      })
+    })
+
+    describe('ARIA 属性', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} ariaLabel="保存ボタン" role="button">
+            保存
+          </BaseButton>
+        )
+      })
+
+      test('aria-label が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('aria-label')).toEqual('保存ボタン')
+      })
+
+      test('role が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('role')).toEqual('button')
+      })
+    })
+
+    describe('children なしの場合', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()} />)
+      })
+
+      test('text 要素は空で出力される', () => {
+        const text = result.container.querySelector('span[class*="baseButton_text"]')
+        expect(text).not.toBe(null)
+        expect(text?.textContent).toBe('')
+      })
     })
   })
 
-  describe('非活性ボタン', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton onClick={() => handleClick()} isDisabled>
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
+  //============================================================================
+  // 2. Display
+  //============================================================================
+  describe('Display', () => {
+    describe('デフォルトサイズ（medium）', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('medium サイズスタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__medium')
+      })
     })
 
-    test('属性が正常に付与されている', () => {
-      const button = result.container.querySelector('button')
-      expect(button?.getAttribute('disabled')).toEqual('')
+    describe('large サイズ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} size="large">
+            test
+          </BaseButton>
+        )
+      })
+
+      test('large サイズスタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__large')
+      })
+    })
+
+    describe('small サイズ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} size="small">
+            test
+          </BaseButton>
+        )
+      })
+
+      test('small サイズスタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__small')
+      })
+    })
+
+    describe('デフォルトバリアント（contained）', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('contained バリアントスタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__contained')
+      })
+    })
+
+    describe('デフォルトカラー（primary）', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('primary カラースタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__primary')
+      })
+    })
+
+    describe('非活性ボタン', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} isDisabled>
+            test
+          </BaseButton>
+        )
+      })
+
+      test('disabled 属性が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('disabled')).toEqual('')
+      })
+
+      test('非活性スタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__disabled')
+      })
+    })
+
+    describe('カスタムクラス名', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton className="custom-class" onClick={() => handleClick()}>
+            test
+          </BaseButton>
+        )
+      })
+
+      test('カスタムクラス名が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.classList.contains('custom-class')).toBe(true)
+      })
+    })
+
+    describe('複数のスタイルプロパティ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} size="large" variant="contained" color="primary">
+            test
+          </BaseButton>
+        )
+      })
+
+      test('すべてのスタイルプロパティが同時に適用される', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton__large')
+        expect(button?.className).toContain('baseButton__contained')
+        expect(button?.className).toContain('baseButton__primary')
+      })
+    })
+
+    describe('内部構造', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('baseButton クラスが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseButton')
+      })
+
+      test('container クラスを持つ span 要素が存在する', () => {
+        const container = result.container.querySelector('span[class*="baseButton_container"]')
+        expect(container).not.toBe(null)
+      })
+
+      test('text クラスを持つ span 要素が存在する', () => {
+        const text = result.container.querySelector('span[class*="baseButton_text"]')
+        expect(text).not.toBe(null)
+        expect(text?.textContent).toBe('test')
+      })
+    })
+
+    describe('リンクボタンのスタイル', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseButton url="/internal/path" size="large" color="primary">
+              test
+            </BaseButton>
+          </MemoryRouter>
+        )
+      })
+
+      test('リンク要素にも BaseButton のスタイルが適用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link?.className).toContain('baseButton')
+        expect(link?.className).toContain('baseButton__large')
+        expect(link?.className).toContain('baseButton__primary')
+      })
     })
   })
 
-  describe('リンクボタン', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton url="https://test.com/">
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
+  //============================================================================
+  // 3. Operation
+  //============================================================================
+  describe('Operation', () => {
+    describe('クリックイベント', () => {
+      beforeEach(() => {
+        result = render(<BaseButton onClick={() => handleClick()}>test</BaseButton>)
+      })
+
+      test('クリックイベントが正常に動作している', () => {
+        const button = result.container.querySelector('button')
+
+        if (!button) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(button)
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
     })
 
-    test('遷移先が正常に設定されている', () => {
-      const button = result.container.querySelector('a')
-      expect(button?.getAttribute('href')).toEqual('https://test.com/')
+    describe('内部リンクボタン', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseButton url="/internal/path">test</BaseButton>
+          </MemoryRouter>
+        )
+      })
+
+      test('Link コンポーネントが使用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link).not.toBe(null)
+        expect(link?.getAttribute('href')).toEqual('/internal/path')
+      })
+    })
+
+    describe('外部リンクボタン', () => {
+      beforeEach(() => {
+        result = render(<BaseButton url="https://example.com">test</BaseButton>)
+      })
+
+      test('a タグが使用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link).not.toBe(null)
+        expect(link?.getAttribute('href')).toEqual('https://example.com')
+      })
+    })
+
+    describe('別タブで開く外部リンクボタン', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton url="https://example.com" target="_blank" rel="noopener">
+            test
+          </BaseButton>
+        )
+      })
+
+      test('target と rel 属性が正常に付与されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link?.getAttribute('target')).toEqual('_blank')
+        expect(link?.getAttribute('rel')).toEqual('noopener')
+      })
+    })
+
+    describe('非活性ボタンのクリック', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseButton onClick={() => handleClick()} isDisabled>
+            test
+          </BaseButton>
+        )
+      })
+
+      test('非活性状態ではクリックイベントが発火しない', () => {
+        const button = result.container.querySelector('button')
+
+        if (!button) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(button)
+        expect(handleClick).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('url と onClick の併用', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseButton url="/path" onClick={() => handleClick()}>
+              test
+            </BaseButton>
+          </MemoryRouter>
+        )
+      })
+
+      test('url がある場合はリンク要素になる', () => {
+        const link = result.container.querySelector('a')
+        const button = result.container.querySelector('button')
+
+        expect(link).not.toBe(null)
+        expect(button).toBe(null)
+      })
+
+      test('onClick も正常に動作する', () => {
+        const link = result.container.querySelector('a')
+
+        if (!link) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(link)
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
     })
   })
 
-  describe('別タブで開くリンクボタン', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton url="https://test.com/" target="_blank" rel="noopener">
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
-    })
+  //============================================================================
+  // 4. Validation (for forms)
+  //============================================================================
+  describe.skip('Validation', () => {})
 
-    test('属性が正常に付与されている', () => {
-      const button = result.container.querySelector('a')
-      expect(button?.getAttribute('target')).toEqual('_blank')
-      expect(button?.getAttribute('rel')).toEqual('noopener')
-    })
-  })
-
-  describe('左要素', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton onClick={() => handleClick()} leftElm={<span className="TestLeft">testLeft</span>}>
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
-    })
-
-    test('要素が正常に出力されている', () => {
-      const button = result.container.querySelector('button')
-      expect(button?.querySelector('.TestLeft')).not.toBe(null)
-    })
-  })
-
-  describe('右要素', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(
-        <BaseButton onClick={() => handleClick()} rightElm={<span className="TestRight">testRight</span>}>
-          <span className="TestText">test</span>
-        </BaseButton>
-      )
-    })
-
-    test('要素が正常に出力されている', () => {
-      const button = result.container.querySelector('button')
-      expect(button?.querySelector('.TestRight')).not.toBe(null)
-    })
-  })
+  //============================================================================
+  // 5. Others (Optional)
+  //============================================================================
+  describe.skip('Others (Optional)', () => {})
 })

--- a/tests/components/ui/icons/SvgIcon/index.test.tsx
+++ b/tests/components/ui/icons/SvgIcon/index.test.tsx
@@ -1,25 +1,144 @@
-import { describe, afterEach, beforeEach, test, expect } from 'vitest'
-import type { RenderResult } from '@testing-library/react'
-import { render, cleanup } from '@testing-library/react'
-import { SvgIcon } from '~/components/ui/icons/SvgIcon'
+import { render, type RenderResult, cleanup } from '@testing-library/react'
+import { describe, vi, beforeEach, afterEach, test, expect } from 'vitest'
+
+import { SvgIcon, type SvgIconVariant } from '~/components/ui/icons/SvgIcon'
 
 describe('SvgIcon', () => {
   let result: RenderResult
 
-  // テスト終了後の処理
   afterEach(() => {
     cleanup()
+    vi.clearAllMocks()
   })
 
-  describe('標準', () => {
-    // テスト開始前の処理
-    beforeEach(() => {
-      result = render(<SvgIcon variant="home" />)
+  //============================================================================
+  // 1. Input/Output
+  //============================================================================
+  describe('Input/Output', () => {
+    describe('基本的なアイコン', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="home" />)
+      })
+
+      test('i 要素がレンダリングされる', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon).not.toBe(null)
+      })
     })
 
-    test('アイコンが正常に出力されている', () => {
-      const icon = result.container.querySelector('i')
-      expect(icon?.className).toContain('home')
+    describe('title 属性', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="home" title="ホーム" />)
+      })
+
+      test('title が正常に付与されている', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.getAttribute('title')).toEqual('ホーム')
+      })
+
+      test('aria-label が正常に付与されている', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.getAttribute('aria-label')).toEqual('ホーム')
+      })
+    })
+
+    describe('title なしの場合', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="home" />)
+      })
+
+      test('title 属性は付与されない', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.getAttribute('title')).toBe(null)
+      })
+
+      test('aria-label 属性は付与されない', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.getAttribute('aria-label')).toBe(null)
+      })
     })
   })
+
+  //============================================================================
+  // 2. Display
+  //============================================================================
+  describe('Display', () => {
+    describe('ベーススタイル', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="home" />)
+      })
+
+      test('svgIcon クラスが適用されている', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.className).toContain('svgIcon')
+      })
+    })
+
+    describe('variant スタイル', () => {
+      const variants: SvgIconVariant[] = [
+        'home',
+        'search',
+        'mail',
+        'liquor',
+        'translate',
+        'keyboardArrowDown',
+        'keyboardArrowLeft',
+        'keyboardArrowRight',
+        'keyboardArrowUp',
+      ]
+
+      variants.forEach((variant) => {
+        test(`${variant} バリアントスタイルが適用されている`, () => {
+          result = render(<SvgIcon variant={variant} />)
+          const icon = result.container.querySelector('i')
+          expect(icon?.className).toContain(`svgIcon__${variant}`)
+          cleanup()
+        })
+      })
+    })
+
+    describe('カスタムクラス名', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="home" className="custom-class" />)
+      })
+
+      test('カスタムクラス名が正常に付与されている', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.classList.contains('custom-class')).toBe(true)
+      })
+
+      test('ベーススタイルも同時に適用されている', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.className).toContain('svgIcon')
+        expect(icon?.className).toContain('svgIcon__home')
+      })
+    })
+
+    describe('className なしの場合', () => {
+      beforeEach(() => {
+        result = render(<SvgIcon variant="search" />)
+      })
+
+      test('ベーススタイルと variant スタイルのみ適用される', () => {
+        const icon = result.container.querySelector('i')
+        expect(icon?.className).toContain('svgIcon')
+        expect(icon?.className).toContain('svgIcon__search')
+      })
+    })
+  })
+
+  //============================================================================
+  // 3. Operation
+  //============================================================================
+  describe.skip('Operation', () => {})
+
+  //============================================================================
+  // 4. Validation (for forms)
+  //============================================================================
+  describe.skip('Validation', () => {})
+
+  //============================================================================
+  // 5. Others (Optional)
+  //============================================================================
+  describe.skip('Others (Optional)', () => {})
 })

--- a/tests/components/ui/lists/BaseTagList/index.test.tsx
+++ b/tests/components/ui/lists/BaseTagList/index.test.tsx
@@ -1,0 +1,284 @@
+import { render, type RenderResult, cleanup } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, vi, beforeEach, afterEach, test, expect } from 'vitest'
+
+import { BaseTagList } from '~/components/ui/lists/BaseTagList'
+import type { BaseTagProps } from '~/components/ui/tags/BaseTag'
+
+describe('BaseTagList', () => {
+  let result: RenderResult
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  //============================================================================
+  // 1. Input/Output
+  //============================================================================
+  describe('Input/Output', () => {
+    describe('基本的なリスト表示', () => {
+      const items: BaseTagProps[] = [{ children: 'Tag 1' }, { children: 'Tag 2' }, { children: 'Tag 3' }]
+
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={items} />
+          </MemoryRouter>
+        )
+      })
+
+      test('指定した数のタグが表示される', () => {
+        const listItems = result.container.querySelectorAll('li')
+        expect(listItems.length).toBe(3)
+      })
+
+      test('各タグのテキストが正しく表示される', () => {
+        expect(result.getByText('Tag 1')).not.toBe(null)
+        expect(result.getByText('Tag 2')).not.toBe(null)
+        expect(result.getByText('Tag 3')).not.toBe(null)
+      })
+    })
+
+    describe('空のリスト', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={[]} />
+          </MemoryRouter>
+        )
+      })
+
+      test('リスト要素は存在するがアイテムは表示されない', () => {
+        const ul = result.container.querySelector('ul')
+        const listItems = result.container.querySelectorAll('li')
+
+        expect(ul).not.toBe(null)
+        expect(listItems.length).toBe(0)
+      })
+    })
+
+    describe('タグのプロパティ伝播', () => {
+      const items: BaseTagProps[] = [
+        { children: 'Link Tag', url: 'https://example.com' },
+        { children: 'Button Tag', onClick: vi.fn() },
+        { children: 'Outlined Tag', variant: 'outlined' },
+      ]
+
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={items} />
+          </MemoryRouter>
+        )
+      })
+
+      test('url を持つタグはリンクとしてレンダリングされる', () => {
+        const link = result.container.querySelector('a[href="https://example.com"]')
+        expect(link).not.toBe(null)
+        expect(link?.textContent).toContain('Link Tag')
+      })
+
+      test('onClick を持つタグはボタンとしてレンダリングされる', () => {
+        const buttons = result.container.querySelectorAll('button')
+        const buttonTexts = Array.from(buttons).map((b) => b.textContent)
+        expect(buttonTexts.some((text) => text?.includes('Button Tag'))).toBe(true)
+      })
+    })
+  })
+
+  //============================================================================
+  // 2. Display
+  //============================================================================
+  describe('Display', () => {
+    describe('セマンティックマークアップ（デフォルト）', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={[{ children: 'Tag' }]} />
+          </MemoryRouter>
+        )
+      })
+
+      test('div 要素でラップされる', () => {
+        const wrapper = result.container.firstElementChild
+        expect(wrapper?.tagName).toBe('DIV')
+      })
+
+      test('ul 要素が使用される', () => {
+        const ul = result.container.querySelector('ul')
+        expect(ul).not.toBe(null)
+      })
+
+      test('li 要素でアイテムがラップされる', () => {
+        const li = result.container.querySelector('li')
+        expect(li).not.toBe(null)
+      })
+    })
+
+    describe('非セマンティックマークアップ', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={[{ children: 'Tag' }]} isNotSemantic />
+          </MemoryRouter>
+        )
+      })
+
+      test('span 要素でラップされる', () => {
+        const wrapper = result.container.firstElementChild
+        expect(wrapper?.tagName).toBe('SPAN')
+      })
+
+      test('ul 要素は使用されない', () => {
+        const ul = result.container.querySelector('ul')
+        expect(ul).toBe(null)
+      })
+
+      test('li 要素は使用されない', () => {
+        const li = result.container.querySelector('li')
+        expect(li).toBe(null)
+      })
+
+      test('全て span 要素で構成される', () => {
+        const spans = result.container.querySelectorAll('span')
+        expect(spans.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('className の適用', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={[{ children: 'Tag' }]} className="custom-class" />
+          </MemoryRouter>
+        )
+      })
+
+      test('カスタムクラス名がラッパーに適用される', () => {
+        const wrapper = result.container.firstElementChild
+        expect(wrapper?.classList.contains('custom-class')).toBe(true)
+      })
+    })
+
+    describe('align プロパティ', () => {
+      describe('left（デフォルト）', () => {
+        beforeEach(() => {
+          result = render(
+            <MemoryRouter>
+              <BaseTagList items={[{ children: 'Tag' }]} />
+            </MemoryRouter>
+          )
+        })
+
+        test('left 用のクラスが適用される', () => {
+          const items = result.container.querySelector('ul')
+          expect(items?.className).toContain('left')
+        })
+      })
+
+      describe('center', () => {
+        beforeEach(() => {
+          result = render(
+            <MemoryRouter>
+              <BaseTagList items={[{ children: 'Tag' }]} align="center" />
+            </MemoryRouter>
+          )
+        })
+
+        test('center 用のクラスが適用される', () => {
+          const items = result.container.querySelector('ul')
+          expect(items?.className).toContain('center')
+        })
+      })
+
+      describe('right', () => {
+        beforeEach(() => {
+          result = render(
+            <MemoryRouter>
+              <BaseTagList items={[{ children: 'Tag' }]} align="right" />
+            </MemoryRouter>
+          )
+        })
+
+        test('right 用のクラスが適用される', () => {
+          const items = result.container.querySelector('ul')
+          expect(items?.className).toContain('right')
+        })
+      })
+    })
+  })
+
+  //============================================================================
+  // 3. Operation
+  //============================================================================
+  describe('Operation', () => {
+    describe('タグのクリックイベント', () => {
+      const handleClick = vi.fn()
+      const items: BaseTagProps[] = [{ children: 'Clickable Tag', onClick: handleClick }]
+
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={items} />
+          </MemoryRouter>
+        )
+      })
+
+      test('タグをクリックするとイベントハンドラが呼ばれる', () => {
+        const button = result.container.querySelector('button')
+        button?.click()
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  //============================================================================
+  // 4. Validation (for forms)
+  //============================================================================
+  // このコンポーネントはフォーム要素ではないため、バリデーションテストは不要
+
+  //============================================================================
+  // 5. Others (Optional)
+  //============================================================================
+  describe('Others', () => {
+    describe('複数アイテムの順序', () => {
+      const items: BaseTagProps[] = [{ children: 'First' }, { children: 'Second' }, { children: 'Third' }]
+
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={items} />
+          </MemoryRouter>
+        )
+      })
+
+      test('アイテムが配列の順序通りに表示される', () => {
+        const listItems = result.container.querySelectorAll('li')
+        expect(listItems[0]?.textContent).toContain('First')
+        expect(listItems[1]?.textContent).toContain('Second')
+        expect(listItems[2]?.textContent).toContain('Third')
+      })
+    })
+
+    describe('異なるバリアントの混在', () => {
+      const items: BaseTagProps[] = [
+        { children: 'Contained', variant: 'contained' },
+        { children: 'Outlined', variant: 'outlined' },
+      ]
+
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTagList items={items} />
+          </MemoryRouter>
+        )
+      })
+
+      test('異なるバリアントのタグが共存できる', () => {
+        expect(result.getByText('Contained')).not.toBe(null)
+        expect(result.getByText('Outlined')).not.toBe(null)
+      })
+    })
+  })
+})

--- a/tests/components/ui/tags/BaseTag/index.test.tsx
+++ b/tests/components/ui/tags/BaseTag/index.test.tsx
@@ -1,0 +1,385 @@
+import { render, type RenderResult, cleanup, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, vi, beforeEach, afterEach, test, expect } from 'vitest'
+
+import { BaseTag } from '~/components/ui/tags/BaseTag'
+
+describe('BaseTag', () => {
+  let result: RenderResult
+  const handleClick: () => void = vi.fn()
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  //============================================================================
+  // 1. Input/Output
+  //============================================================================
+  describe('Input/Output', () => {
+    describe('基本的なタグ', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('children が正常に出力されている', () => {
+        const span = result.container.querySelector('span')
+        expect(span).not.toBe(null)
+        expect(span?.textContent).toBe('test')
+      })
+    })
+
+    describe('leftElm と rightElm', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseTag leftElm={<span data-testid="left">Left</span>} rightElm={<span data-testid="right">Right</span>}>
+            Center
+          </BaseTag>
+        )
+      })
+
+      test('leftElm が正常に出力されている', () => {
+        const leftElm = result.getByTestId('left')
+        expect(leftElm).not.toBe(null)
+        expect(leftElm.textContent).toBe('Left')
+      })
+
+      test('rightElm が正常に出力されている', () => {
+        const rightElm = result.getByTestId('right')
+        expect(rightElm).not.toBe(null)
+        expect(rightElm.textContent).toBe('Right')
+      })
+
+      test('children が正常に出力されている', () => {
+        const text = result.container.querySelector('span[class*="baseTag_text"]')
+        expect(text?.textContent).toBe('Center')
+      })
+    })
+
+    describe('leftElm のみ', () => {
+      beforeEach(() => {
+        result = render(<BaseTag leftElm={<span data-testid="left">Icon</span>}>Tag</BaseTag>)
+      })
+
+      test('leftElm が正常に出力されている', () => {
+        const leftElm = result.getByTestId('left')
+        expect(leftElm).not.toBe(null)
+      })
+
+      test('rightElm は出力されていない', () => {
+        const rightElm = result.queryByTestId('right')
+        expect(rightElm).toBe(null)
+      })
+    })
+
+    describe('rightElm のみ', () => {
+      beforeEach(() => {
+        result = render(<BaseTag rightElm={<span data-testid="right">X</span>}>Tag</BaseTag>)
+      })
+
+      test('rightElm が正常に出力されている', () => {
+        const rightElm = result.getByTestId('right')
+        expect(rightElm).not.toBe(null)
+      })
+
+      test('leftElm は出力されていない', () => {
+        const leftElm = result.queryByTestId('left')
+        expect(leftElm).toBe(null)
+      })
+    })
+
+    describe('children なしの場合', () => {
+      beforeEach(() => {
+        result = render(<BaseTag />)
+      })
+
+      test('text 要素は空で出力される', () => {
+        const text = result.container.querySelector('span[class*="baseTag_text"]')
+        expect(text).not.toBe(null)
+        expect(text?.textContent).toBe('')
+      })
+    })
+  })
+
+  //============================================================================
+  // 2. Display
+  //============================================================================
+  describe('Display', () => {
+    describe('ベーススタイル', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('baseTag クラスが適用されている', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.className).toContain('baseTag')
+      })
+    })
+
+    describe('デフォルトバリアント（contained）', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('contained バリアントスタイルが適用されている', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.className).toContain('baseTag__contained')
+      })
+    })
+
+    describe('outlined バリアント', () => {
+      beforeEach(() => {
+        result = render(<BaseTag variant="outlined">test</BaseTag>)
+      })
+
+      test('outlined バリアントスタイルが適用されている', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.className).toContain('baseTag__outlined')
+      })
+    })
+
+    describe('デフォルトカラー（sub）', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('sub カラースタイルが適用されている', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.className).toContain('baseTag__sub')
+      })
+    })
+
+    describe('onClick がある場合', () => {
+      beforeEach(() => {
+        result = render(<BaseTag onClick={() => handleClick()}>test</BaseTag>)
+      })
+
+      test('baseTag__button スタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseTag__button')
+      })
+    })
+
+    describe('url がある場合', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTag url="/path">test</BaseTag>
+          </MemoryRouter>
+        )
+      })
+
+      test('baseTag__button スタイルが適用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link?.className).toContain('baseTag__button')
+      })
+    })
+
+    describe('onClick も url もない場合', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('baseTag__button スタイルは適用されない', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.className).not.toContain('baseTag__button')
+      })
+    })
+
+    describe('非活性タグ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseTag onClick={() => handleClick()} isDisabled>
+            test
+          </BaseTag>
+        )
+      })
+
+      test('disabled 属性が正常に付与されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.getAttribute('disabled')).toEqual('')
+      })
+
+      test('非活性スタイルが適用されている', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseTag__disabled')
+      })
+    })
+
+    describe('カスタムクラス名', () => {
+      beforeEach(() => {
+        result = render(<BaseTag className="custom-class">test</BaseTag>)
+      })
+
+      test('カスタムクラス名が正常に付与されている', () => {
+        const tag = result.container.querySelector('span[class*="baseTag"]')
+        expect(tag?.classList.contains('custom-class')).toBe(true)
+      })
+    })
+
+    describe('複数のスタイルプロパティ', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseTag variant="outlined" color="sub" onClick={() => handleClick()}>
+            test
+          </BaseTag>
+        )
+      })
+
+      test('すべてのスタイルプロパティが同時に適用される', () => {
+        const button = result.container.querySelector('button')
+        expect(button?.className).toContain('baseTag__outlined')
+        expect(button?.className).toContain('baseTag__sub')
+        expect(button?.className).toContain('baseTag__button')
+      })
+    })
+
+    describe('内部構造', () => {
+      beforeEach(() => {
+        result = render(<BaseTag>test</BaseTag>)
+      })
+
+      test('container クラスを持つ span 要素が存在する', () => {
+        const container = result.container.querySelector('span[class*="baseTag_container"]')
+        expect(container).not.toBe(null)
+      })
+
+      test('text クラスを持つ span 要素が存在する', () => {
+        const text = result.container.querySelector('span[class*="baseTag_text"]')
+        expect(text).not.toBe(null)
+        expect(text?.textContent).toBe('test')
+      })
+    })
+
+    describe('リンクタグのスタイル', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTag url="/path" variant="outlined">
+              test
+            </BaseTag>
+          </MemoryRouter>
+        )
+      })
+
+      test('リンク要素にも BaseTag のスタイルが適用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link?.className).toContain('baseTag')
+        expect(link?.className).toContain('baseTag__outlined')
+        expect(link?.className).toContain('baseTag__button')
+      })
+    })
+  })
+
+  //============================================================================
+  // 3. Operation
+  //============================================================================
+  describe('Operation', () => {
+    describe('クリックイベント', () => {
+      beforeEach(() => {
+        result = render(<BaseTag onClick={() => handleClick()}>test</BaseTag>)
+      })
+
+      test('クリックイベントが正常に動作している', () => {
+        const button = result.container.querySelector('button')
+
+        if (!button) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(button)
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('内部リンクタグ', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTag url="/internal/path">test</BaseTag>
+          </MemoryRouter>
+        )
+      })
+
+      test('Link コンポーネントが使用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link).not.toBe(null)
+        expect(link?.getAttribute('href')).toEqual('/internal/path')
+      })
+    })
+
+    describe('外部リンクタグ', () => {
+      beforeEach(() => {
+        result = render(<BaseTag url="https://example.com">test</BaseTag>)
+      })
+
+      test('a タグが使用されている', () => {
+        const link = result.container.querySelector('a')
+        expect(link).not.toBe(null)
+        expect(link?.getAttribute('href')).toEqual('https://example.com')
+      })
+    })
+
+    describe('非活性タグのクリック', () => {
+      beforeEach(() => {
+        result = render(
+          <BaseTag onClick={() => handleClick()} isDisabled>
+            test
+          </BaseTag>
+        )
+      })
+
+      test('非活性状態ではクリックイベントが発火しない', () => {
+        const button = result.container.querySelector('button')
+
+        if (!button) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(button)
+        expect(handleClick).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('url と onClick の併用', () => {
+      beforeEach(() => {
+        result = render(
+          <MemoryRouter>
+            <BaseTag url="/path" onClick={() => handleClick()}>
+              test
+            </BaseTag>
+          </MemoryRouter>
+        )
+      })
+
+      test('url がある場合はリンク要素になる', () => {
+        const link = result.container.querySelector('a')
+        const button = result.container.querySelector('button')
+
+        expect(link).not.toBe(null)
+        expect(button).toBe(null)
+      })
+
+      test('onClick も正常に動作する', () => {
+        const link = result.container.querySelector('a')
+
+        if (!link) {
+          throw new Error('The target element was not found.')
+        }
+
+        fireEvent.click(link)
+        expect(handleClick).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  //============================================================================
+  // 4. Validation (for forms)
+  //============================================================================
+  describe.skip('Validation', () => {})
+
+  //============================================================================
+  // 5. Others (Optional)
+  //============================================================================
+  describe.skip('Others (Optional)', () => {})
+})


### PR DESCRIPTION
## 概要

- BaseTagコンポーネントを作成

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces tag UI components and upgrades PrimitiveButton with ARIA/title/role and hash-link handling, alongside Storybook config tweaks and expanded tests/stories.
> 
> - **UI Components**:
>   - **`BaseTag`**: New tag component with variants (`contained`/`outlined`), color `sub`, button/link/span modes, left/right elements, and disabled/hover styles (`app/components/ui/tags/BaseTag/*`).
>   - **`BaseTagList`**: New list component supporting semantic/non-semantic wrappers and `align` (`left`/`center`/`right`) (`app/components/ui/lists/BaseTagList/*`).
>   - **`PrimitiveButton`**: Adds `title`, `role`, `tabIndex`, and ARIA props; detects hash links; computes default `type`; falls back to `span` when no action (`app/components/primitives/buttons/PrimitiveButton/index.tsx`).
>   - **`BaseButton`**: Simplifies className handling and child rendering (`app/components/ui/buttons/BaseButton/index.tsx`).
> - **Storybook**:
>   - Use `@storybook/react-vite` types in stories; refine Vite config with `fileURLToPath`, explicit `ConfigEnv`, `tsconfigPaths`, and `define.process.env.NODE_DEBUG=false` (`.storybook/main.ts`, `stories/**/*`).
> - **Tests**:
>   - Add/expand tests for `PrimitiveButton`, `BaseButton`, `SvgIcon`, `BaseTag`, and `BaseTagList` covering rendering, attributes, interactions, and variants (`tests/**/*`).
> - **Stories**:
>   - New stories for `BaseTag` and `BaseTagList`; update existing component stories to new Storybook typings (`stories/**/*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a0da81be407aec1d61432bb1294a9cc152a133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->