### PR TITLE
fix: use || instead of ?? for drink slug fallback to handle empty strings

### DIFF
--- a/app/utils/article.ts
+++ b/app/utils/article.ts
@@ -29,7 +29,7 @@ export const convertDrinksToArticleCardProps = ({
     button: {
       url: PAGES.SG20_101.getUrl({
         lang,
-        params: { drinkId: drink.slug ?? drink.topics_id },
+        params: { drinkId: drink.slug || drink.topics_id },
       }),
     },
     title: {

--- a/tests/utils/article.test.ts
+++ b/tests/utils/article.test.ts
@@ -80,11 +80,20 @@ describe('convertDrinksToArticleCardProps', () => {
 
     it('slugがundefinedの場合、topics_idにフォールバックする', () => {
       const drink = createDrink({ topics_id: 789 })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ;(drink as any).slug = undefined
+      // @ts-expect-error: slugにundefinedを代入してフォールバック動作をテスト
+      drink.slug = undefined
       const result = convertDrinksToArticleCardProps({ ...defaultArgs, drink })
 
       expect(result.button?.url).toBe('/drinks/789')
+    })
+
+    it('slugがnullの場合、topics_idにフォールバックする', () => {
+      const drink = createDrink({ topics_id: 101 })
+      // @ts-expect-error: slugにnullを代入してフォールバック動作をテスト
+      drink.slug = null
+      const result = convertDrinksToArticleCardProps({ ...defaultArgs, drink })
+
+      expect(result.button?.url).toBe('/drinks/101')
     })
   })
 })

--- a/tests/utils/article.test.ts
+++ b/tests/utils/article.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+
+import { convertDrinksToArticleCardProps } from '~/utils/article'
+
+import type { Drink } from '~/types/api/drinks'
+
+const createDrink = (overrides: Partial<Drink> = {}): Drink => {
+  return {
+    topics_id: 123,
+    ymd: new Date('2024-01-15'),
+    contents_type: 1,
+    contents: 'contents',
+    subject: 'テスト飲料',
+    topics_flg: 1,
+    open_flg: 1,
+    regular_flg: 0,
+    inst_ymdhi: new Date('2024-01-15T10:00:00+09:00'),
+    update_ymdhi: new Date('2024-01-15T10:00:00+09:00'),
+    topics_group_id: 1,
+    post_time: '2024-01-15T10:00:00+09:00',
+    slug: 'test-drink',
+    ai_postprocess_state: '',
+    group_nm: 'group',
+    group_description: 'description',
+    contents_type_cnt: 1,
+    contents_type_nm: 'type',
+    contents_type_slug: null,
+    contents_type_parent_nm: null,
+    category_parent_id: null,
+    contents_type_ext_col_01: null,
+    contents_type_ext_col_02: null,
+    contents_type_ext_col_03: null,
+    contents_type_ext_col_04: null,
+    contents_type_ext_col_05: null,
+    tags: [],
+    contents_type_list: [1],
+    description: 'description',
+    thumbnail: {
+      id: '1',
+      url: 'https://example.com/thumb.jpg',
+      desc: 'thumbnail',
+      url_org: 'https://example.com/thumb_org.jpg',
+    },
+    main_visuals: [],
+    manufacturer: 'メーカー',
+    abv: 5,
+    drink_category: { key: '1', label: 'ビール' },
+    links: [],
+    comment: 'comment',
+    subject_en: 'Test Drink',
+    description_en: 'description en',
+    contents_en: 'contents en',
+    manufacturer_en: 'Manufacturer',
+    comment_en: 'comment en',
+    ...overrides,
+  }
+}
+
+const defaultArgs = {
+  lang: 'ja',
+  tags: [],
+  drinkCategories: [],
+}
+
+describe('convertDrinksToArticleCardProps', () => {
+  describe('url slug fallback', () => {
+    it('slugが有効な文字列の場合、slugがURLに使われる', () => {
+      const drink = createDrink({ slug: 'my-drink', topics_id: 456 })
+      const result = convertDrinksToArticleCardProps({ ...defaultArgs, drink })
+
+      expect(result.button?.url).toBe('/drinks/my-drink')
+    })
+
+    it('slugが空文字の場合、topics_idにフォールバックする', () => {
+      const drink = createDrink({ slug: '', topics_id: 456 })
+      const result = convertDrinksToArticleCardProps({ ...defaultArgs, drink })
+
+      expect(result.button?.url).toBe('/drinks/456')
+    })
+
+    it('slugがundefinedの場合、topics_idにフォールバックする', () => {
+      const drink = createDrink({ topics_id: 789 })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(drink as any).slug = undefined
+      const result = convertDrinksToArticleCardProps({ ...defaultArgs, drink })
+
+      expect(result.button?.url).toBe('/drinks/789')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- `convertDrinksToArticleCardProps` の `drink.slug ?? drink.topics_id` で、`slug` が空文字 `""` の場合に `??`（nullish coalescing）がフォールバックせず、`/drinks/` という不正なURLが生成されるバグを修正
- `??` を `||`（論理OR）に変更し、空文字の場合も `drink.topics_id` にフォールバックされるように修正

## Details
- 変更箇所: `app/utils/article.ts` L32
- `??` は `null` と `undefined` のみフォールバックするため、空文字 `""` はそのまま使われていた
- `||` は falsy 値（空文字、`0`、`null`、`undefined`）全てでフォールバックする

## Test plan
- [x] slugが空文字のdrinkデータで、生成されるURLに `topics_id` が含まれることを確認
- [x] slugが有効な文字列のdrinkデータで、生成されるURLにslugが含まれることを確認
- [x] slugが `null` / `undefined` のdrinkデータで、生成されるURLに `topics_id` が含まれることを確認