### PR TITLE
style: add type modifiers to type-only imports

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,6 +28,10 @@
         "prefer-rest-params": "error",
         "prefer-spread": "error",
         "typescript/ban-ts-comment": "error",
+        "typescript/consistent-type-imports": [
+          "error",
+          { "fixStyle": "inline-type-imports", "disallowTypeAnnotations": false }
+        ],
         "typescript/no-duplicate-enum-values": "error",
         "typescript/no-empty-object-type": "error",
         "typescript/no-explicit-any": "error",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,5 @@
 // const toPath = (filePath) => path.join(process.cwd(), filePath)
-import { StorybookConfig } from '@storybook/react-vite'
+import { type StorybookConfig } from '@storybook/react-vite'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { loadConfigFromFile, mergeConfig, type ConfigEnv } from 'vite'

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import { Preview } from '@storybook/react-vite'
+import { type Preview } from '@storybook/react-vite'
 import { useEffect } from 'react'
 import { I18nextProvider } from 'react-i18next'
 

--- a/app/routes/($lang)._public._layout.drinks.$drinkId._index/route.tsx
+++ b/app/routes/($lang)._public._layout.drinks.$drinkId._index/route.tsx
@@ -13,7 +13,7 @@ import { LayoutSection } from '~/components/ui/layouts/LayoutSection'
 import { ArticleCardList } from '~/components/ui/lists/ArticleCardList'
 import { SectionTitle } from '~/components/ui/typographies/SectionTitle'
 import { PAGES } from '~/config/paths'
-import { loader as drinkDetailLoader } from '~/routes/($lang)._public._layout.drinks.$drinkId/route'
+import { type loader as drinkDetailLoader } from '~/routes/($lang)._public._layout.drinks.$drinkId/route'
 import { getLang } from '~/utils/locale'
 import { getMetadata } from '~/utils/meta'
 

--- a/app/utils/locale.ts
+++ b/app/utils/locale.ts
@@ -1,4 +1,4 @@
-import { Params } from 'react-router'
+import { type Params } from 'react-router'
 
 import { LANG, PAGE_INFO, SITE_INFO } from '~/config/consts'
 


### PR DESCRIPTION
## 概要

プロジェクト内の「`type` を付けられる import すべて」に `type` 修飾子を付与しました。

## アプローチ

手作業ではなく、oxlint の `typescript/consistent-type-imports` ルールを使って網羅的に変換しました。

- `.oxlintrc.json` に以下のルールを追加（今後も自動で強制されます）:
  ```json
  "typescript/consistent-type-imports": [
    "error",
    { "fixStyle": "inline-type-imports", "disallowTypeAnnotations": false }
  ]
  ```
  - `fixStyle: "inline-type-imports"` … 既存コードで支配的だった `import { type Foo, bar }` のインラインスタイルに合わせ、差分を最小化
  - `disallowTypeAnnotations: false` … `tests/server/csrf.server.test.ts` の `vi.mock` 内で使われている `typeof import('~/config/env')` という慣用句を壊さないため（import 宣言のみを対象に）
- `oxlint --fix` で一括適用

## 変更ファイル

コードベースは元々ほとんどの import に `type` が付与済みで、未対応だったのは以下のみでした:

- `.storybook/main.ts` … `type StorybookConfig`
- `.storybook/preview.tsx` … `type Preview`
- `app/routes/($lang)._public._layout.drinks.$drinkId._index/route.tsx` … `type loader as drinkDetailLoader`
- `app/utils/locale.ts` … `type Params`

## 検証

- `npm run typecheck` ✅
- `npm run lint`（`--max-warnings=0`）✅
- `npm run format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRGDjmAeUNo8x3LimDWB2H)_